### PR TITLE
Current dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Windows users should see [Rtools](http://cran.r-project.org/bin/windows/Rtools/)
 You will need to install R packages that ANTsR requires. Minimally:
 **Install ITKR and ANTsRCore** [here](https://github.com/stnava/ITKR/releases) and [here](https://github.com/ANTsX/ANTsRCore/releases) then do:
 ```
-mydeps <- c( "Rcpp", "RcppEigen", "tools", "methods", "magrittr", "rsvd" )
+mydeps <- c( "Rcpp", "RcppEigen", "magrittr", "rsvd", "magic", "psych" )
 install.packages( pkgs = mydeps, dependencies = TRUE )
 ```
 You can gain additional functionality by installing packages that


### PR DESCRIPTION
Building with a new R install, I needed these packages

  mydeps <- c( "Rcpp", "RcppEigen", "magrittr", "rsvd", "magic", "psych" )

I took out "base" and "methods" because these generate warnings about not changing base packages.