### PR TITLE
FIX: example code was broken

### DIFF
--- a/R/eanatDef.R
+++ b/R/eanatDef.R
@@ -48,8 +48,8 @@ if ( sum(mask==1) != ncol(mat) ) stop("Mask must match mat")
 if ( selectorScale < 1 ) selectorScale = 1.1
 mxn = nrow(mat)-1
 if ( maxNEvec > 1 & maxNEvec < mxn ) mxn = maxNEvec
-if ( fastsvd & !whiten ) solutionmatrix = t( rsvd::rsvd( mat, nu=0, nv=mxn )$v )
-if ( !fastsvd & !whiten ) solutionmatrix = t( svd( mat, nu=0, nv=mxn )$v )
+if ( fastsvd & !whiten ) solutionmatrix = t( rsvd::rsvd( mat, nu=1, nv=mxn )$v )
+if ( !fastsvd & !whiten ) solutionmatrix = t( svd( mat, nu=1, nv=mxn )$v )
 if ( whiten ) solutionmatrix = icawhiten( mat, mxn )
 mycorrs = rep( NA, mxn )
 if ( verbose ) progress <- txtProgressBar(min = 2, max = mxn, style = 3)


### PR DESCRIPTION
When running the provided example, I got the following error:

Error in t.default(rsvd::rsvd(mat, nu = 0, nv = mxn)$v) :
 argument is not a matrix

I found that if either nu or nv is set to zero, then neither v nor u are returned. Setting nu to anything > 0 seems to fix it so that v is returned. I'm running rsvd 0.9, so not sure if it's a version dependent issue.