### PR TITLE
ENH:  Coordinate default params across ANTsX packages.

### DIFF
--- a/R/kellyKapowski.R
+++ b/R/kellyKapowski.R
@@ -30,7 +30,7 @@
 #' @export kellyKapowski
 kellyKapowski <- function( s, g, w,
    its = 45, r = 0.025,
-   m = 1.5,  x = TRUE,
+   m = 1.5,  x = FALSE,
    e = FALSE,
    q = NULL,
    timeSigma = 1,


### PR DESCRIPTION
``m_UseMaskedSmoothing`` is [turned off](https://github.com/ANTsX/ANTs/blob/master/Utilities/itkDiReCTImageFilter.hxx#L66) by default.  [The parameter is not set in ANTsPy](https://github.com/ANTsX/ANTsPy/blob/master/ants/segmentation/kelly_kapowski.py#L11-L37).  Since the 2014, 2019, and 2021 evaluations all used either the ANTs or ANTsPy version, I'm changing the ANTsR parameter set to be consistent with the other two.