### PR TITLE
FIX: remove name collisions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Depends:
     R (>= 3.0),
     methods
 Imports:
-    ANTsRCore (>= 0.8.0)
+    ANTsRCore (>= 0.8.0),
     graphics,
     grDevices,
     magrittr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,9 +24,9 @@ License: Apache License 2.0
 LazyLoad: yes
 Depends:
     R (>= 3.0),
-    methods,
-    ANTsRCore (>= 0.8.0)
+    methods
 Imports:
+    ANTsRCore (>= 0.8.0)
     graphics,
     grDevices,
     magrittr,

--- a/R/antsAffineInitializer.R
+++ b/R/antsAffineInitializer.R
@@ -56,6 +56,6 @@ affineInitializer <- function(
     veccer <- lappend(veccer, mask)
   }
   xxx <- .int_antsProcessArguments(veccer)
-  temp <- ANTsRCore::antsAffineInitializer(xxx)
+  temp <- ANTsRCore::AntsAffineInitializer(xxx)
   return(txfn)
 }

--- a/R/antsApplyTransforms.R
+++ b/R/antsApplyTransforms.R
@@ -119,7 +119,7 @@ antsApplyTransforms <- function(
     compose = NA, verbose = FALSE, ...) {
   if (is.character(fixed)) {
     if (fixed == "-h") {
-      ANTsRCore::antsApplyTransforms(.int_antsProcessArguments(
+      ANTsRCore::AntsApplyTransforms(.int_antsProcessArguments(
         list("-h")
       ))
       return()
@@ -241,7 +241,7 @@ antsApplyTransforms <- function(
       }
       myverb <- as.numeric(verbose)
       if (verbose) print(myargs)
-      ANTsRCore::antsApplyTransforms(c(myargs, "-z", 1, "-v", myverb, "--float", 1, "-e", imagetype))
+      ANTsRCore::AntsApplyTransforms(c(myargs, "-z", 1, "-v", myverb, "--float", 1, "-e", imagetype))
 
       if (is.na(compose)) {
         return(antsImageClone(warpedmovout, inpixeltype))
@@ -264,7 +264,7 @@ antsApplyTransforms <- function(
   # if ( Sys.info()['sysname'] == 'XXX' ) { mycmd<-.antsrParseListToString( c(args)
   # ) system( paste('antsApplyTransforms ', mycmd$mystr ) ) return( antsImageRead(
   # mycmd$outimg, as.numeric(mycmd$outdim) ) ) }
-  ANTsRCore::antsApplyTransforms(.int_antsProcessArguments(
+  ANTsRCore::AntsApplyTransforms(.int_antsProcessArguments(
     c(args, "-z", 1, "--float", 1, "-e", imagetype)
   ))
 }

--- a/R/antsApplyTransformsToPoints.R
+++ b/R/antsApplyTransformsToPoints.R
@@ -123,7 +123,7 @@ antsApplyTransformsToPoints <- function(
         }
       }
     }
-    ANTsRCore::antsApplyTransformsToPoints(c(myargs, "-f", 1, "--precision", 0))
+    ANTsRCore::AntsApplyTransforms(c(myargs, "-f", 1, "--precision", 0))
 
     if (inherits(points, "antsImage")) {
       return(pointsout)

--- a/R/antsImageClone.R
+++ b/R/antsImageClone.R
@@ -34,11 +34,11 @@ antsImageClone <- function(in_image, out_pixeltype = in_image@pixeltype) {
     mychanns <- splitChannels(in_image)
     for (k in 1:length(mychanns))
     {
-      img_clone <- ANTsRCore::antsImageClone(mychanns[[k]], out_pixeltype)
+      img_clone <- ANTsRCore::AntsImageClone(mychanns[[k]], out_pixeltype)
       mychanns[[k]] <- img_clone
     }
     return(mergeChannels(mychanns))
   }
 
-  ANTsRCore::antsImageClone(in_image, out_pixeltype)
+  ANTsRCore::AntsImageClone(in_image, out_pixeltype)
 }

--- a/R/antsImageHeaderInfo.R
+++ b/R/antsImageHeaderInfo.R
@@ -39,6 +39,6 @@ antsImageHeaderInfo <- function(filename) {
     stop("File does not exist")
   }
 
-  ret <- ANTsRCore::antsImageHeaderInfo(filename)
+  ret <- ANTsRCore::AntsImageHeaderInfo(filename)
   return(ret)
 }

--- a/R/antsImageIterator_class.R
+++ b/R/antsImageIterator_class.R
@@ -40,7 +40,7 @@ setMethod(f = "show", "antsImageIterator", function(object) {
 setMethod(f = "initialize", signature(.Object = "antsImageIterator"), definition = function(
     .Object,
     pixeltype = "float", dimension = 3, components = 1) {
-  ANTsRCore::antsImageIterator(pixeltype, dimension, components)
+  ANTsRCore::AntsImageIterator(pixeltype, dimension, components)
 })
 
 #' @title antsImageIterator
@@ -53,7 +53,7 @@ setMethod(f = "initialize", signature(.Object = "antsImageIterator"), definition
 #' @export
 antsImageIterator <- function(x) {
   x <- check_ants(x)
-  return(ANTsRCore::antsImageIterator(x))
+  return(ANTsRCore::AntsImageIterator(x))
 }
 
 #' @title antsImageIteratorGet

--- a/R/antsImageRead.R
+++ b/R/antsImageRead.R
@@ -58,7 +58,7 @@ antsImageRead <- function(filename, dimension = NULL, pixeltype = "float") {
   }
 
   rval <- try(
-    ANTsRCore::antsImageRead(
+    ANTsRCore::AntsImageRead(
       filename, pixeltype,
       dimension, components
     )

--- a/R/antsImageStats.R
+++ b/R/antsImageStats.R
@@ -3,7 +3,7 @@ antsImageStats <- function(image, mask = NULL, na.rm = FALSE) {
     mask <- check_ants(mask)
   }
   image <- antsImageClone(image, out_pixeltype = "double")
-  res <- ANTsRCore::antsImageStats(image, mask, na.rm)
+  res <- ANTsRCore::AntsImageStats(image, mask, na.rm)
   check <- !any(sapply(res, is.raw))
   if (!check) {
     stop("raw output form antsImageStats, please report this bug")

--- a/R/antsImageWrite.R
+++ b/R/antsImageWrite.R
@@ -54,5 +54,5 @@ antsImageWrite <- function(image, filename, as.tensor = FALSE) {
     }
   }
 
-  invisible(ANTsRCore::antsImageWrite(image, filename, as.tensor))
+  invisible(ANTsRCore::AntsImageWrite(image, filename, as.tensor))
 }

--- a/R/antsMotionCorr.R
+++ b/R/antsMotionCorr.R
@@ -39,5 +39,5 @@
 #'
 #' @export antsMotionCorr
 antsMotionCorr <- function(paramList) {
-  returnval <- ANTsRCore::antsMotionCorr(.int_antsProcessArguments(paramList))
+  returnval <- ANTsRCore::AntsMotionCorr(.int_antsProcessArguments(paramList))
 }

--- a/R/antsRegistration.R
+++ b/R/antsRegistration.R
@@ -226,7 +226,7 @@ antsRegistration <- function(
     printArgs = FALSE, ...) {
   numargs <- nargs()
   if (numargs == 1 & typeof(fixed) == "list") {
-    ANTsRCore::antsRegistration(.int_antsProcessArguments(c(fixed)))
+    ANTsRCore::AntsRegistration(.int_antsProcessArguments(c(fixed)))
     return(0)
   }
   if (nchar(typeofTransform) == 0) {
@@ -272,7 +272,7 @@ antsRegistration <- function(
       "u=\"1\", o=\"[xtest,xtest.nii.gz,xtest_inv.nii.gz]\" ) )\n"
     ))
     cat("full help: \n")
-    ANTsRCore::antsRegistration(.int_antsProcessArguments(c(list("--help"))))
+    ANTsRCore::AntsRegistration(.int_antsProcessArguments(c(list("--help"))))
     return(0)
   }
 
@@ -990,7 +990,7 @@ antsRegistration <- function(
         cat("antsRegistration", paste(unlist(args)), "\n")
       }
       args <- .int_antsProcessArguments(c(args))
-      ANTsRCore::antsRegistration(args)
+      ANTsRCore::AntsRegistration(args)
 
       all_tx <- find_tx(outprefix)
       alltx <- all_tx$alltx
@@ -1061,7 +1061,7 @@ antsRegistration <- function(
     cat("antsRegistration", paste(unlist(args)), "\n")
   }
   args <- .int_antsProcessArguments(c(args))
-  ANTsRCore::antsRegistration(args)
+  ANTsRCore::AntsRegistration(args)
 }
 
 ################################

--- a/R/cropImage.R
+++ b/R/cropImage.R
@@ -26,7 +26,7 @@ cropImage <- function(image, labelImage, label = 1) {
   if (image@pixeltype != "float" | labelImage@pixeltype != "float") {
     stop("input images must have float pixeltype")
   }
-  ANTsRCore::cropImage(image, labelImage, label, 0, NULL, NULL)
+  ANTsRCore::CropImage(image, labelImage, label, 0, NULL, NULL)
 }
 
 
@@ -144,5 +144,5 @@ extractSlice <- function(image, slice, direction, collapseStrategy = 0) {
   if (collapseStrategy != 0 && collapseStrategy != 1 && collapseStrategy != 2) {
     stop("collapseStrategy must be 0, 1, or 2.")
   }
-  ANTsRCore::extractSlice(image, slice - 1, direction - 1, collapseStrategy)
+  ANTsRCore::ExtractSlice(image, slice - 1, direction - 1, collapseStrategy)
 }

--- a/R/fitBsplineDisplacementField.R
+++ b/R/fitBsplineDisplacementField.R
@@ -149,7 +149,7 @@ fitBsplineDisplacementField <- function(
     numberOfControlPoints <- rep(numberOfControlPoints, dimensionality)
   }
 
-  bsplineField <- ANTsRCore::fitBsplineDisplacementField(
+  bsplineField <- ANTsRCore::fitBsplineDisplacementFieldR(
     dimensionality,
     displacementField, displacementWeightImage,
     displacementOrigins, displacements, displacementWeights,

--- a/R/fitBsplineObjectToScatteredData.R
+++ b/R/fitBsplineObjectToScatteredData.R
@@ -148,7 +148,7 @@ fitBsplineObjectToScatteredData <- function(
     stop("Error:  the number of weights is not the same as the number of points.")
   }
 
-  bsplineObject <- ANTsRCore::fitBsplineObjectToScatteredData(
+  bsplineObject <- ANTsRCore::fitBsplineObjectToScatteredDataR(
     scatteredData, parametricData, dataWeights,
     parametricDomainOrigin, parametricDomainSpacing,
     parametricDomainSize, isParametricDimensionClosed,

--- a/R/fitThinPlateSplineDisplacementField.R
+++ b/R/fitThinPlateSplineDisplacementField.R
@@ -80,7 +80,7 @@ fitThinPlateSplineDisplacementField <- function(
     stop("Error:  direction is not of size dimensionality x dimensionality.")
   }
 
-  tpsField <- ANTsRCore::fitThinPlateSplineDisplacementField(
+  tpsField <- ANTsRCore::fitThinPlateSplineDisplacementFieldR(
     dimensionality,
     displacementOrigins, displacements,
     origin, spacing, size, direction

--- a/R/fsl2antsrTransform.R
+++ b/R/fsl2antsrTransform.R
@@ -15,6 +15,6 @@
 #'
 #' @export fsl2antsrTransform
 fsl2antsrTransform <- function(matrix, reference, moving) {
-  retval <- ANTsRCore::fsl2antsrTransform(matrix, reference, moving, 1)
+  retval <- ANTsRCore::fsl2antsrTransformR(matrix, reference, moving, 1)
   return(retval)
 }

--- a/R/imagesToMatrix.R
+++ b/R/imagesToMatrix.R
@@ -39,5 +39,5 @@ imagesToMatrix <- function(imageList, mask) {
     print("Must pass a list of filenames")
     return(NA)
   }
-  return(ANTsRCore::imagesToMatrix(imageList, mask, n))
+  return(ANTsRCore::imagesToMatrixR(imageList, mask, n))
 }

--- a/R/integrateVelocityField.R
+++ b/R/integrateVelocityField.R
@@ -25,7 +25,7 @@ integrateVelocityField <- function(
     numberOfIntegrationSteps = 10) {
   dimensionality <- velocityField@dimension - 1
 
-  integratedField <- ANTsRCore::integrateVelocityField(
+  integratedField <- ANTsRCore::integrateVelocityFieldR(
     dimensionality,
     velocityField,
     as.numeric(lowerIntegrationBound),

--- a/R/invertDisplacementField.R
+++ b/R/invertDisplacementField.R
@@ -23,7 +23,7 @@ invertDisplacementField <- function(
     enforceBoundaryCondition = TRUE) {
   dimensionality <- displacementField@dimension
 
-  inverseField <- ANTsRCore::invertDisplacementField(
+  inverseField <- ANTsRCore::invertDisplacementFieldR(
     dimensionality,
     displacementField,
     inverseFieldInitialEstimate,

--- a/R/labelStats.R
+++ b/R/labelStats.R
@@ -31,7 +31,7 @@ labelStats <- function(image, labelImage) {
   }
   image.float <- antsImageClone(image, "float")
   labelImage.int <- antsImageClone(labelImage, "unsigned int")
-  df <- ANTsRCore::labelStats(image.float, labelImage.int)
+  df <- ANTsRCore::labelStatsR(image.float, labelImage.int)
   df <- df[order(df$LabelValue), ]
   df
 }

--- a/R/mergeChannels.R
+++ b/R/mergeChannels.R
@@ -30,6 +30,6 @@ mergeChannels <- function(imageList) {
     }
   }
 
-  img <- ANTsRCore::mergeChannels(imageList)
+  img <- ANTsRCore::mergeChannelsR(imageList)
   return(img)
 }

--- a/R/reflectImage.R
+++ b/R/reflectImage.R
@@ -32,7 +32,7 @@ reflectImage <- function(
   }
 
   rflct <- tempfile(fileext = ".mat")
-  catchout <- ANTsRCore::reflectionMatrix(img1, axis, rflct)
+  catchout <- ANTsRCore::reflectionMatrixR(img1, axis, rflct)
 
   if (!all(is.na(tx))) {
     rfi <- antsRegistration(img1, img1,
@@ -71,6 +71,6 @@ reflectionMatrix <- function(img1, axis = NA, reflectionMatrixFilename) {
   if (missing(reflectionMatrixFilename)) {
     reflectionMatrixFilename <- tempfile(fileext = ".mat")
   }
-  catchout <- ANTsRCore::reflectionMatrix(img1, axis, reflectionMatrixFilename)
+  catchout <- ANTsRCore::reflectionMatrixR(img1, axis, reflectionMatrixFilename)
   return(reflectionMatrixFilename)
 }

--- a/R/reorientImage.R
+++ b/R/reorientImage.R
@@ -39,7 +39,7 @@ reorientImage <- function(
   if (is.na(txfn)) {
     txfn <- tempfile(fileext = ".mat")
   }
-  ANTsRCore::reorientImage(img, txfn, axis1, axis2, doreflection, doscale)
+  ANTsRCore::reorientImageR(img, txfn, axis1, axis2, doreflection, doscale)
   img2 <- antsApplyTransforms(img, img, transformlist = c(txfn))
   return(list(reoimg = img2, txfn = txfn))
 }

--- a/R/resampleImageToTarget.R
+++ b/R/resampleImageToTarget.R
@@ -118,7 +118,7 @@ resampleImageToTarget <- function(image, target, interpType = "linear",
       if (verbose) {
         print(myargs)
       }
-      ANTsRCore::antsApplyTransforms(c(
+      ANTsRCore::AntsApplyTransforms(c(
         myargs, "-z", 1, "-v",
         myverb, "--float", 1, "-e", imagetype
       ))
@@ -135,7 +135,7 @@ resampleImageToTarget <- function(image, target, interpType = "linear",
     }
     return(1)
   }
-  ANTsRCore::antsApplyTransforms(
+  ANTsRCore::AntsApplyTransforms(
     .int_antsProcessArguments(
       c(args, "-z", 1, "--float", 1, "-e", imagetype)
     )

--- a/R/smoothImage.R
+++ b/R/smoothImage.R
@@ -77,7 +77,7 @@ smoothImage <- function(inimg,
       sigma <- sigma / 2.355
     }
     max_kernel_width <- as.integer(ceiling(max_kernel_width))
-    outimg <- ANTsRCore::smoothImage(
+    outimg <- ANTsRCore::smoothImageR(
       inimg.float,
       outimg,
       sigma,

--- a/R/splitChannels.R
+++ b/R/splitChannels.R
@@ -31,5 +31,5 @@ splitChannels <- function(image) {
     stop("input must have more than 1 components")
   }
 
-  ANTsRCore::splitChannels(image)
+  ANTsRCore::splitChannelsR(image)
 }

--- a/R/weingartenImageCurvature.R
+++ b/R/weingartenImageCurvature.R
@@ -48,7 +48,7 @@ weingartenImageCurvature <- function(image, sigma = 1.0, opt = "mean", labeled =
   optnum <- 0
   if (opt == "gaussian") optnum <- 6
   if (opt == "characterize") optnum <- 5
-  mykout <- ANTsRCore::weingartenImageCurvature(
+  mykout <- ANTsRCore::weingartenImageCurvatureR(
     temp, sigma, optnum, as.integer(labeled)
   )
   if (image@dimension == 3) {


### PR DESCRIPTION
There are some functions named the same thing in ANTsRCore and ANTsR. This is leading to some namespace collisions as people are calling the internal ANTsRCore function instead of the ANTsR function. Most functions in ANTsRCore have some kind of difference from the user-facing ANTsR function already, but some are missing that. This PR adds that for the rest.