### PR TITLE
FIX: move ANTsRCore to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,9 +24,9 @@ License: Apache License 2.0
 LazyLoad: yes
 Depends:
     R (>= 3.0),
-    methods,
-    ANTsRCore (>= 0.8.0)
+    methods
 Imports:
+    ANTsRCore (>= 0.8.0)
     graphics,
     grDevices,
     magrittr,


### PR DESCRIPTION
Previously, ANTsRCore was in Depend which means it was attached when ANTsR was loaded. This means functions with the same name in ANTsRCore will be available when they shouldn't be. This fixes that issue by only importing ANTsRCore.