### PR TITLE
BUG:  Add antsRegistrationSyN family of deformable-only transforms.

### DIFF
--- a/R/antsRegistration.R
+++ b/R/antsRegistration.R
@@ -415,7 +415,11 @@ antsRegistration <- function(
       # If no transform is provided, default to align the centers of mass UNLESS the tranform
       # is one of the "deformable only" transforms
       if (length(initx) == 1 && is.na(initx)) {
-        deformableOnlyTransforms <- c("SyNOnly", "ElasticOnly", "TVMSQ", "TVMSQC", tvTypes)
+        deformableOnlyTransforms <- c("SyNOnly", "ElasticOnly", "TVMSQ", "TVMSQC", 
+            "antsRegistrationSyN[so]", "antsRegistrationSyNQuick[so]", 
+            "antsRegistrationSyNRepro[so]", "antsRegistrationSyNQuickRepro[so]",
+            "antsRegistrationSyN[bo]", "antsRegistrationSyNQuick[bo]",
+            "antsRegistrationSyNRepro[bo]", "antsRegistrationSyNQuickRepro[bo]", tvTypes)
 
         if ((typeofTransform %in% deformableOnlyTransforms)) {
           initx <- "Identity"


### PR DESCRIPTION
Hey @cookpa , I just came across this issue where it doesn't appear that the antsRegistrationSyN family got added in ANTsR unlike ANTsPy.  Can you just check to make sure I'm understanding correctly?